### PR TITLE
changed migration and seed data to include date only

### DIFF
--- a/migrations/20181206162707_dates.js
+++ b/migrations/20181206162707_dates.js
@@ -2,7 +2,7 @@ exports.up = knex =>
   knex.schema.createTable('dates', t => {
     t.increments('id').primary()
     t.integer('user_id').references('users.id')
-    t.timestamps(true, true)
+    t.date('created_at')
   })
 
 exports.down = knex => knex.schema.dropTable('dates')

--- a/migrations/20181206162707_dates.js
+++ b/migrations/20181206162707_dates.js
@@ -2,7 +2,7 @@ exports.up = knex =>
   knex.schema.createTable('dates', t => {
     t.increments('id').primary()
     t.integer('user_id').references('users.id')
-    t.date('created_at')
+    t.date('record_date')
   })
 
 exports.down = knex => knex.schema.dropTable('dates')

--- a/seeds/c_dates.js
+++ b/seeds/c_dates.js
@@ -2,15 +2,15 @@ exports.seed = knex =>
   knex('dates').del()
     .then(() =>
       knex('dates').insert([
-        {id: 1, user_id: 1, created_at: '2018-11-15'},
-        {id: 2, user_id: 1, created_at: '2018-11-17'},
-        {id: 3, user_id: 1, created_at: '2018-11-21'},
-        {id: 4, user_id: 1, created_at: '2018-11-25'},
-        {id: 5, user_id: 1, created_at: '2018-12-02'},
-        {id: 6, user_id: 1, created_at: '2018-12-03'},
-        {id: 7, user_id: 1, created_at: '2018-12-05'},
-        {id: 8, user_id: 1, created_at: '2018-12-06'},
-        {id: 9, user_id: 1, created_at: '2018-12-07'},
-        {id: 10, user_id: 1, created_at: '2018-12-08'}
+        {id: 1, user_id: 1, record_date: '2018-11-15'},
+        {id: 2, user_id: 1, record_date: '2018-11-17'},
+        {id: 3, user_id: 1, record_date: '2018-11-21'},
+        {id: 4, user_id: 1, record_date: '2018-11-25'},
+        {id: 5, user_id: 1, record_date: '2018-12-02'},
+        {id: 6, user_id: 1, record_date: '2018-12-03'},
+        {id: 7, user_id: 1, record_date: '2018-12-05'},
+        {id: 8, user_id: 1, record_date: '2018-12-06'},
+        {id: 9, user_id: 1, record_date: '2018-12-07'},
+        {id: 10, user_id: 1, record_date: '2018-12-08'}
       ])
     )

--- a/seeds/c_dates.js
+++ b/seeds/c_dates.js
@@ -2,15 +2,15 @@ exports.seed = knex =>
   knex('dates').del()
     .then(() =>
       knex('dates').insert([
-        {id: 1, user_id: 1, created_at: '2018-11-15 21:35:55'},
-        {id: 2, user_id: 1, created_at: '2018-11-17 21:35:55'},
-        {id: 3, user_id: 1, created_at: '2018-11-21 21:35:55'},
-        {id: 4, user_id: 1, created_at: '2018-11-25 21:35:55'},
-        {id: 5, user_id: 1, created_at: '2018-12-02 21:35:55'},
-        {id: 6, user_id: 1, created_at: '2018-12-03 21:35:55'},
-        {id: 7, user_id: 1, created_at: '2018-12-05 21:35:55'},
-        {id: 8, user_id: 1, created_at: '2018-12-06 21:35:55'},
-        {id: 9, user_id: 1, created_at: '2018-12-07 21:35:55'},
-        {id: 10, user_id: 1, created_at: '2018-12-08 21:35:55'}
+        {id: 1, user_id: 1, created_at: '2018-11-15'},
+        {id: 2, user_id: 1, created_at: '2018-11-17'},
+        {id: 3, user_id: 1, created_at: '2018-11-21'},
+        {id: 4, user_id: 1, created_at: '2018-11-25'},
+        {id: 5, user_id: 1, created_at: '2018-12-02'},
+        {id: 6, user_id: 1, created_at: '2018-12-03'},
+        {id: 7, user_id: 1, created_at: '2018-12-05'},
+        {id: 8, user_id: 1, created_at: '2018-12-06'},
+        {id: 9, user_id: 1, created_at: '2018-12-07'},
+        {id: 10, user_id: 1, created_at: '2018-12-08'}
       ])
     )

--- a/server/db/graph.js
+++ b/server/db/graph.js
@@ -3,8 +3,8 @@ const connection = require('./')
 function getDates (userId, startDate, endDate, db = connection) {
   return db('dates')
     .where('user_id', '=', userId)
-    .where('created_at', '>=', startDate)
-    .where('created_at', '<=', endDate)
+    .where('record_date', '>=', startDate)
+    .where('record_date', '<=', endDate)
     .select()
 }
 

--- a/server/routes/dates.js
+++ b/server/routes/dates.js
@@ -74,10 +74,9 @@ router.get('/graph/:userId/:endDate', (req, res) => {
           // rearrange the data as graph component wants
           chartData.labels = []
           for (date of dates) {
-            chartData.labels.push(date.created_at.slice(5, 10))
+            chartData.labels.push(date.record_date.slice(5, 10))
           }
           chartData.datasets = []
-
           // get activity names
           activities.getActivities()
             .then(actis => {


### PR DESCRIPTION
#138 dates migration and seed changed to date rather than date and time. date column changed to "record_date" and all instances of "created_at" throughout code changed to "record_date".
Checked graph component and data still being retrieved correctly after a yarn updateDB.